### PR TITLE
Extract valid callsign from YSF for DMR ID lookup and use compile-tim…

### DIFF
--- a/reflector/Callsign.cpp
+++ b/reflector/Callsign.cpp
@@ -112,10 +112,10 @@ bool CCallsign::IsValid(void) const
 	}
 
 	// prefix
-	// all chars are number, uppercase or space
+	// all chars are number, letter, special char, or space
 	for ( i = 0; i < CALLSUFFIX_LEN; i++ )
 	{
-		valid &= IsLetter(m_Suffix[i]) || IsNumber(m_Suffix[i]) || IsSpace(m_Suffix[i]);
+		 valid &= IsLetter(m_Suffix[i]) || IsNumber(m_Suffix[i]) || IsSpace(m_Suffix[i]) || IsLetterLC(m_Suffix[i]) || IsSpecialChar(m_Suffix[i]);
 	}
 
 	// module
@@ -369,6 +369,16 @@ bool CCallsign::IsLetter(char c) const
 bool CCallsign::IsSpace(char c) const
 {
 	return (c == ' ');
+}
+
+bool CCallsign::IsLetterLC(char c) const
+{
+	return ((c >= 'a') && (c <= 'z'));
+}
+
+bool CCallsign::IsSpecialChar(char c) const
+{
+    return ((c >= '!') && (c <= '/'));
 }
 
 void CCallsign::CodeIn(const uint8_t *in)

--- a/reflector/Callsign.h
+++ b/reflector/Callsign.h
@@ -84,6 +84,8 @@ protected:
 	bool IsNumber(char) const;
 	bool IsLetter(char) const;
 	bool IsSpace(char) const;
+	bool IsLetterLC(char) const;
+    bool IsSpecialChar(char) const;
 
 protected:
 	// data

--- a/reflector/DMRMMDVMProtocol.cpp
+++ b/reflector/DMRMMDVMProtocol.cpp
@@ -859,12 +859,28 @@ void CDmrmmdvmProtocol::EncodeMMDVMPacket(const CDvHeaderPacket &Header, const C
 {
 	uint8_t tag[] = { 'D','M','R','D' };
 	Buffer->Set(tag, sizeof(tag));
-
+	uint8_t cs[12];
+	
 	// DMR header
 	// uiSeqId
 	Buffer->Append((uint8_t)seqid);
 	// uiSrcId
 	uint32_t uiSrcId = Header.GetMyCallsign().GetDmrid();
+	DvFrame0.GetMyCallsign().GetCallsign(cs);
+	
+    if(uiSrcId == 0){
+		uiSrcId = DvFrame0.GetMyCallsign().GetDmrid();
+	}
+	if(uiSrcId == 0){
+		uiSrcId = DvFrame1.GetMyCallsign().GetDmrid();
+	}
+	if(uiSrcId == 0){
+		uiSrcId = DvFrame2.GetMyCallsign().GetDmrid();
+	}
+	if(uiSrcId == 0){
+		uiSrcId = DMRMMDVM_DEFAULTID;
+	}
+	
 	AppendDmrIdToBuffer(Buffer, uiSrcId);
 	// uiDstId = TG9
 	uint32_t uiDstId = 9; // ModuleToDmrDestId(Header.GetRpt2Module());

--- a/reflector/DVFramePacket.cpp
+++ b/reflector/DVFramePacket.cpp
@@ -59,7 +59,7 @@ CDvFramePacket::CDvFramePacket(const uint8_t *ambe, const uint8_t *sync, uint16_
 }
 
 // ysf constructor
-CDvFramePacket::CDvFramePacket(const uint8_t *ambe, uint16_t sid, uint8_t pid, uint8_t spid, uint8_t fid, bool islast)
+CDvFramePacket::CDvFramePacket(const uint8_t *ambe, uint16_t sid, uint8_t pid, uint8_t spid, uint8_t fid, CCallsign cs, bool islast)
 	: CPacket(sid, pid, spid, fid, islast)
 {
 	memcpy(m_TCPack.dmr, ambe, 9);
@@ -69,6 +69,9 @@ CDvFramePacket::CDvFramePacket(const uint8_t *ambe, uint16_t sid, uint8_t pid, u
 	memset(m_TCPack.m17, 0, 16);
 	memset(m_Nonce, 0, 14);
 	m_TCPack.codec_in = ECodecType::dmr;
+	uint8_t c[12];
+    cs.GetCallsign(c);
+    m_Callsign.SetCallsign((char *)c);
 }
 
 // bm constructor

--- a/reflector/DVFramePacket.h
+++ b/reflector/DVFramePacket.h
@@ -19,6 +19,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 #include "Packet.h"
+#include "Callsign.h"
 
 ////////////////////////////////////////////////////////////////////////////////////////
 // defines
@@ -45,7 +46,7 @@ public:
 	// DMR Frame
 	CDvFramePacket(const uint8_t *ambe, const uint8_t *sync, uint16_t streamid, uint8_t counter1, uint8_t counter2, bool islast);
 	// YSF Frame
-	CDvFramePacket(const uint8_t *ambe, uint16_t streamid, uint8_t counter1, uint8_t counter2, uint8_t counter3, bool islast);
+	CDvFramePacket(const uint8_t *ambe, uint16_t streamid, uint8_t counter1, uint8_t counter2, uint8_t counter3, CCallsign cs, bool islast);
 	// XLX Frame
 	CDvFramePacket(uint16_t streamid, uint8_t counter, const uint8_t *ambe, const uint8_t *dvdata, uint8_t counter1, uint8_t counter2, const uint8_t *ambe2, const uint8_t *dmrsync, ECodecType type, bool islast);
 	// M17 Frame
@@ -68,6 +69,7 @@ public:
 	const uint8_t *GetDvSync(void) const { return m_uiDvSync; }
 	const uint8_t *GetDvData(void) const { return m_uiDvData; }
 	const uint8_t *GetNonce(void)  const { return m_Nonce; }
+	const CCallsign &GetMyCallsign(void) const { return m_Callsign; }
 
 	// set
 	void SetDvData(const uint8_t *);
@@ -86,4 +88,5 @@ protected:
 	uint8_t m_Nonce[14];
 	// the transcoder packet
 	STCPacket m_TCPack;
+	CCallsign m_Callsign;
 };

--- a/reflector/DVHeaderPacket.cpp
+++ b/reflector/DVHeaderPacket.cpp
@@ -22,6 +22,7 @@
 #include "DMRIdDir.h"
 #include "DVHeaderPacket.h"
 
+
 ////////////////////////////////////////////////////////////////////////////////////////
 // constructor
 
@@ -89,6 +90,17 @@ CDvHeaderPacket::CDvHeaderPacket(const struct dstar_header *buffer, uint16_t sid
 	m_uiFlag2 = buffer->Flag2;
 	m_uiFlag3 = buffer->Flag3;
 	m_csUR.SetCallsign(buffer->UR, CALLSIGN_LEN);
+	
+	if((buffer->RPT1)[7] == 0x20){
+		char rptr1[8];
+		memcpy(rptr1, buffer->RPT1, 8);
+		rptr1[7] = DPLUS_DEFAULT_RPTR1_SUFFIX;
+		m_csRPT1.SetCallsign(rptr1, CALLSIGN_LEN);
+	}
+	else{
+		m_csRPT1.SetCallsign(buffer->RPT1, CALLSIGN_LEN);
+	}
+	
 	m_csRPT1.SetCallsign(buffer->RPT1, CALLSIGN_LEN);
 	m_csRPT2.SetCallsign(buffer->RPT2, CALLSIGN_LEN);
 	m_csMY.SetCallsign(buffer->MY, CALLSIGN_LEN);

--- a/reflector/Main.h
+++ b/reflector/Main.h
@@ -92,6 +92,7 @@ enum class EProtocol { any, none, dextra, dplus, dcs, bm, urf, dmrplus, dmrmmdvm
 #define DPLUS_PORT                      20001                               // UDP port
 #define DPLUS_KEEPALIVE_PERIOD          1                                   // in seconds
 #define DPLUS_KEEPALIVE_TIMEOUT         (DPLUS_KEEPALIVE_PERIOD*10)         // in seconds
+#define DPLUS_DEFAULT_RPTR1_SUFFIX      'Y'
 
 // DCS
 #define DCS_PORT                        30051                               // UDP port
@@ -123,6 +124,7 @@ enum class EProtocol { any, none, dextra, dplus, dcs, bm, urf, dmrplus, dmrmmdvm
 #define DMRMMDVM_KEEPALIVE_TIMEOUT      (DMRMMDVM_KEEPALIVE_PERIOD*10)      // in seconds
 #define DMRMMDVM_REFLECTOR_SLOT         DMR_SLOT2
 #define DMRMMDVM_REFLECTOR_COLOUR       1
+#define DMRMMDVM_DEFAULTID              0
 
 // YSF
 #define YSF_PORT                        42000                               // UDP port


### PR DESCRIPTION
…e default when no valid callsign found.  When YSF header is missed (late-entry), receive callsign from V/D frames.  Add compile-time default character to RPTR1 when missing.