### PR TITLE
Fix default interlink file, title in index page.

### DIFF
--- a/dashboard/index.php
+++ b/dashboard/index.php
@@ -86,7 +86,7 @@ if ($CallingHome['Active']) {
     <meta name="robots" content="<?php echo $PageOptions['MetaAuthor']; ?>"/>
 
     <meta http-equiv="content-type" content="text/html; charset=utf-8"/>
-    <title><?php echo str_replace("XLX", "URF", $Reflector->GetReflectorName()); ?>Universal Reflector</title>
+    <title><?php echo str_replace("XLX", "URF", $Reflector->GetReflectorName()); ?> Universal Reflector</title>
     <link rel="icon" href="./favicon.ico" type="image/vnd.microsoft.icon">
     <!-- Bootstrap core CSS -->
     <link href="css/bootstrap.min.css" rel="stylesheet">

--- a/dashboard/pgs/config.inc.php
+++ b/dashboard/pgs/config.inc.php
@@ -62,7 +62,7 @@ $CallingHome['Comment']                              = "your_comment"; 				     
 $CallingHome['HashFile']                             = "/xlxd-ch/callinghome.php";             // Make sure the apache user has read and write permissions in this folder.
 $CallingHome['LastCallHomefile']                     = "/xlxd-ch/lastcallhome.php";            // lastcallhome.php can remain in the tmp folder
 $CallingHome['OverrideIPAddress']                    = "";                                     // Insert your IP address here. Leave blank for autodetection. No need to enter a fake address.
-$CallingHome['InterlinkFile']                        = "/usr/local/etc/xlxd.interlink";        // Path to interlink file
+$CallingHome['InterlinkFile']                        = "/usr/local/etc/urfd.interlink";        // Path to interlink file
 
 /*
   include an extra config file for people who dont like to mess with shipped config.ing.php


### PR DESCRIPTION
Fixes the default interlink file name from xlxd.interlink to urfd.interlink and adds a space in the title section of index.php.