### PR TITLE
Correctly sets size in bind/connect to fixed name of abstract

### DIFF
--- a/reflector/UnixDgramSocket.cpp
+++ b/reflector/UnixDgramSocket.cpp
@@ -48,7 +48,9 @@ bool CUnixDgramReader::Open(const char *path)	// returns true on failure
 	addr.sun_family = AF_UNIX;
 	strncpy(addr.sun_path+1, path, sizeof(addr.sun_path)-2);
 
-	int rval = bind(fd, (struct sockaddr *)&addr, sizeof(addr));
+	// We know path is a string, so we skip the first null, get the string length and add 1 for the begining Null
+	int path_len = sizeof(addr.sun_family) + strlen(addr.sun_path + 1) + 1;
+	int rval = bind(fd, (struct sockaddr *)&addr, path_len);
 	if (rval < 0)
 	{
 		std::cerr << "bind() failed for " << path << ": " << strerror(errno) << std::endl;
@@ -139,7 +141,9 @@ ssize_t CUnixDgramWriter::Write(const void *buf, ssize_t size) const
 		return -1;
 	}
 	// connect to the receiver
-	int rval = connect(fd, (struct sockaddr *)&addr, sizeof(addr));
+	// We know path is a string, so we skip the first null, get the string length and add 1 for the begining Null
+	int path_len = sizeof(addr.sun_family) + strlen(addr.sun_path + 1) + 1;
+	int rval = connect(fd, (struct sockaddr *)&addr, path_len);
 	if (rval < 0)
 	{
 		std::cerr << "connect() failed for " << addr.sun_path+1 << ": " << strerror(errno) << std::endl;


### PR DESCRIPTION
When looking at the socket using `lsof -U`, currently the socket name is end padded with nulls. The fix to this (according to stack overflow - https://stackoverflow.com/a/31020275 ) is to set the length in the bind/connect. The length set in the bind/connect should not be the full length of the struct, but the length of the `sun_family` plus the string length of path including the leading null. 

This PR creates a `path_len` variable that is the size of `sun_family` + the strlen of the sun_path after the null (other wise it would be 0) + 1 for the leading null.  I used strlen of sun_path since in the connect function we don't know the original path and we know the path is a string as it's hard coded. 

lsof prior to patch: 
```
root@f115b4ffe53c:/# lsof -U
COMMAND PID USER   FD   TYPE             DEVICE SIZE/OFF     NODE NAME
urfd      1 root   31u  unix 0x0000000000000000      0t0 55133132 @TC2URFModA@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@ type=DGRAM
```

lsof after patch: 
```
root@7a18226a278c:/# lsof -U
COMMAND PID USER   FD   TYPE             DEVICE SIZE/OFF  NODE NAME
urfd      1 root   32u  unix 0x0000000000000000      0t0 79425 @TC2URFModA type=DGRAM
```