### PR TITLE
Fix dashboard timestamp issue due to #6f6b73b

### DIFF
--- a/dashboard/pgs/functions.php
+++ b/dashboard/pgs/functions.php
@@ -12,37 +12,10 @@ function Debug($message) {
 }
 
 function ParseTime($Input) {
-   
     if (strpos($Input, "<") !== false) {
-       $Input = substr($Input, 0, strpos($Input, "<"));
+        $Input = substr($Input, 0, strpos($Input, "<"));
     }
-    
-    // Tuesday Tue Nov 17 14:23:22 2015
-    $tmp  = explode(" ", $Input);
-    if (strlen(trim($tmp[3])) == 0) {
-       unset($tmp[3]);
-       $tmp = array_values($tmp);
-    }
-
-    $tmp1 = explode(":", $tmp[4]); 
-    $month = "";
-    switch (strtolower($tmp[2])) {
-      case 'jan' : $month = 1; break;
-      case 'feb' : $month = 2; break;
-      case 'mar' : $month = 3; break;
-      case 'apr' : $month = 4; break;
-      case 'may' : $month = 5; break;
-      case 'jun' : $month = 6; break;
-      case 'jul' : $month = 7; break;
-      case 'aug' : $month = 8; break;
-      case 'sep' : $month = 9; break;
-      case 'oct' : $month = 10; break;
-      case 'nov' : $month = 11; break;
-      case 'dec' : $month = 12; break;
-      default    : $month = 1; 
-    }
-    return @mktime($tmp1[0], $tmp1[1], $tmp1[2], $month, $tmp[3], $tmp[5]);
-    
+    return strtotime($Input);
 }
 
 function FormatSeconds($seconds) {


### PR DESCRIPTION
Due to timestamp changes in #6f6b73b, it "broke" the dashboard timestamp'ing (everything was "1969"). This commit/PR fixes that issue.